### PR TITLE
WIP: Rename custom id field.

### DIFF
--- a/src/main/java/io/youscan/elasticsearch/shard/YQueriesLoaderCollector.java
+++ b/src/main/java/io/youscan/elasticsearch/shard/YQueriesLoaderCollector.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 public class YQueriesLoaderCollector  implements Collector, LeafCollector {
 
-    public static final String ID_FIELD = "id";
+    public static final String ID_FIELD = "ysid"; //We're using custom id field. Elastic ignores "id"
     private final Map<String, QueryAndSource> queries = Maps.newHashMap();
     private final FieldsVisitor fieldsVisitor;
     private final YPercolatorQueriesRegistry percolator;


### PR DESCRIPTION
"id" name is not elastic friendly and therefore
does not end up in the mapping, which is very
VERY important for loading queries at ES restart
Elastic simply can't get that field from the
mapping and fails to repopulate queries collection
when node is restarted.
Following error is written to ES log for 2.4 perc

```
at org.elasticsearch.index.shard.StoreRecoveryService$1.run(StoreRecoveryService.java:179)
ypercolator_1                   | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
ypercolator_1                   | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
ypercolator_1                   | 	at java.lang.Thread.run(Thread.java:745)
ypercolator_1                   | Caused by: YPercolatorQueryException[failed to load queries from percolator index]; nested: NullPointerException;
ypercolator_1                   | 	at io.youscan.elasticsearch.shard.YPercolatorQueriesRegistry$ShardLifecycleListener.loadQueries(YPercolatorQueriesRegistry.java:251)
ypercolator_1                   | 	at io.youscan.elasticsearch.shard.YPercolatorQueriesRegistry$ShardLifecycleListener.beforeIndexShardPostRecovery(YPercolatorQueriesRegistry.java:218)
ypercolator_1                   | 	at org.elasticsearch.indices.InternalIndicesLifecycle.beforeIndexShardPostRecovery(InternalIndicesLifecycle.java:126)
ypercolator_1                   | 	at org.elasticsearch.index.shard.IndexShard.postRecovery(IndexShard.java:883)
ypercolator_1                   | 	at org.elasticsearch.index.shard.StoreRecoveryService.recoverFromStore(StoreRecoveryService.java:248)
ypercolator_1                   | 	at org.elasticsearch.index.shard.StoreRecoveryService.access$100(StoreRecoveryService.java:56)
ypercolator_1                   | 	at org.elasticsearch.index.shard.StoreRecoveryService$1.run(StoreRecoveryService.java:129)
ypercolator_1                   | 	... 3 more
ypercolator_1                   | Caused by: java.lang.NullPointerException
ypercolator_1                   | 	at org.elasticsearch.index.fielddata.IndexFieldDataService.getForField(IndexFieldDataService.java:218)
ypercolator_1                   | 	at io.youscan.elasticsearch.shard.YQueriesLoaderCollector.<init>(YQueriesLoaderCollector.java:40)
ypercolator_1                   | 	at io.youscan.elasticsearch.shard.YPercolatorQueriesRegistry$ShardLifecycleListener.loadQueries(YPercolatorQueriesRegistry.java:243)
```

With `ysid` field in percolator and obviously in
query registration, ES successfully repopulates
queries cache on a node restart.